### PR TITLE
Update start.ca API endpoint. …

### DIFF
--- a/tekuila/isp/startca.py
+++ b/tekuila/isp/startca.py
@@ -30,7 +30,7 @@ from xml.parsers.expat import ExpatError
 
 class StartCA(Tekuila):
     """Fetch and parse Start.ca quota API"""
-    API_URL = '/support/usage/api?key='
+    API_URL = '/account/usage/api?key='
 
     def __init__(self, apikey=None, cap=None, warn_ratio=None, verbose=False):
         super(self.__class__, self).__init__(apikey, cap, warn_ratio, verbose)


### PR DESCRIPTION
With recent start.ca website changes, the old API endpoint was returning:

    "Data fetch failed. HTTP: Moved Permanently"

With this change it now works again for start.ca using test: "tekuila --startca --api API_KEY --cap 0".

